### PR TITLE
popup suppression to prevent provision hangup

### DIFF
--- a/kubeadm-master-ubuntu.sh
+++ b/kubeadm-master-ubuntu.sh
@@ -29,7 +29,8 @@ sudo apt-key adv \
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 sudo groupadd docker
 sudo usermod -aG docker vagrant
-sudo apt-get install python-pip -y
+#noninteractive mode on python-pip install stops interactive popup hanging script
+sudo DEBIAN_FRONTEND=noninteractive apt-get -yq install python-pip
 sudo apt-get install joe -y
 sudo -H pip install --upgrade pip
 

--- a/kubeadm-node-ubuntu.sh
+++ b/kubeadm-node-ubuntu.sh
@@ -28,7 +28,8 @@ sudo apt-key adv \
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 sudo groupadd docker
 sudo usermod -aG docker ubuntu
-sudo apt-get install python-pip -y
+#noninteractive mode on python-pip install stops interactive popup hanging script
+sudo DEBIAN_FRONTEND=noninteractive apt-get -yq install python-pip
 sudo apt-get install joe -y
 sudo pip install --upgrade pip
 


### PR DESCRIPTION
Some interactive alerts pop up after updating python-pip using apt-get. These scripts suppress the popup so vagrant's provision shell scripts can setup environments, k8s, etc. 